### PR TITLE
Add WheelTick message for raw encoder ticks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ find_package(catkin REQUIRED COMPONENTS
 add_message_files(
   FILES
   HuskyStatus.msg
+  HuskyWheelTick.msg
 )
 
 generate_messages(

--- a/msg/HuskyWheelTick.msg
+++ b/msg/HuskyWheelTick.msg
@@ -1,0 +1,3 @@
+Header header
+string[] name
+int32[] tickCount


### PR DESCRIPTION
Companion PR to husky_base to allow for wheel encoder ticks to be reported up the ROS stack.
